### PR TITLE
Fix description typo and add repo link to mod.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_C_FLAGS -m32)
 set(CMAKE_CXX_FLAGS -m32)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-project(level-pronouns VERSION 1.0.0)
+project(level-pronouns VERSION 1.0.4)
 
 file(GLOB SOURCES
 	src/*.cpp

--- a/mod.json
+++ b/mod.json
@@ -4,7 +4,8 @@
 	"id": "n.level_pronouns",
 	"name": "Level Pronouns",
 	"developer": "n",
-	"description": "Enchance 2.2 with pronouns on levels!",
+	"description": "Enhance 2.2 with pronouns on levels!",
+	"repository": "https://github.com/NicknameGG/level-pronouns",
 	"dependencies": [
 		{
 			"id": "geode.node-ids",

--- a/mod.json
+++ b/mod.json
@@ -1,6 +1,6 @@
 {
 	"geode": "2.0.0",
-	"version": "v1.0.3",
+	"version": "v1.0.4",
 	"id": "n.level_pronouns",
 	"name": "Level Pronouns",
 	"developer": "n",


### PR DESCRIPTION
This fixes a typo in the description and adds a link to this repository to the mod info.